### PR TITLE
Removed Theme.paddingLarge * 2 from Slider

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -726,7 +726,7 @@ Page {
                 value: mainWindow.curVol
                 label: value + "%"
                 valueText: value + "%"
-                width: parent.width - Theme.paddingLarge * 2
+                width: parent.width
                 onSliderValueChanged: {
                     mainWindow.maxVol = value
                 }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -712,11 +712,8 @@ Page {
             PageHeader {
                 title: qsTr("Max Vol")
             }
-            Label {
-                x: Theme.paddingLarge
+            SectionHeader {
                 text: qsTr("Set maximum volume")
-                color: Theme.secondaryHighlightColor
-                font.pixelSize: Theme.fontSizeExtraLarge
             }
             Slider {
                 id: volMax

--- a/translations/harbour-maxvol-ru.ts
+++ b/translations/harbour-maxvol-ru.ts
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="ru_RU">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="83"/>
+        <source>A simple app to set maximum volume.</source>
+        <translation>Простое приложение для настройки максимальной громкости.</translation>
+    </message>
+</context>
+<context>
+    <name>CoverPage</name>
+    <message>
+        <location filename="../qml/cover/CoverPage.qml" line="39"/>
+        <source>Max Vol: </source>
+        <translation>Громкость: </translation>
+    </message>
+</context>
+<context>
+    <name>FirstPage</name>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="697"/>
+        <source>About</source>
+        <translation>О программе</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="713"/>
+        <source>Max Vol</source>
+        <translation>Max Vol</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="717"/>
+        <source>Set maximum volume</source>
+        <translation>Настройте максимальную громкость</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="738"/>
+        <source>Restore default value</source>
+        <translation>Восстановить значения</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirstPage.qml" line="749"/>
+        <source>Apply after every reboot</source>
+        <translation>Применять после каждой перезагрузки</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Slider looks much better (in the center of the page) without Theme.paddingLarge \* 2, or add anchors, please =)
